### PR TITLE
Don't query entire list of resources.

### DIFF
--- a/ckanext/nhs/helpers.py
+++ b/ckanext/nhs/helpers.py
@@ -127,9 +127,10 @@ def get_latest_datasets():
 def get_latest_resources():
     context = {}
     number_of_active_resources = model.Resource.active().count()
+    offset = 0 if (number_of_active_resources < 10) else (number_of_active_resources - 10)
     data_dict = {
         'query': 'name:',
-        'offset': number_of_active_resources - 10
+        'offset': offset
     }
 
     resources = _get_action('resource_search', context, data_dict)['results']


### PR DESCRIPTION
The current logic was to query all resources and identify newest 5 for display on home page. However, that solution is causing performance issues as the number of resources has grown. At the moment it trie to read ~150 resource objects which is causing slow response time.

## Analysis

The `nhs` extension is here - https://github.com/datopian/nhs - it introduces custom helpers for getting new resources to display on home page:

So on home page, it tries to get the latest resources which is very expensive... e.g., in their code they hit `resource_search` API and then they sort it:

https://github.com/datopian/nhs/blob/82acfe81173971b37449773b063eff3625c2743f/ckanext/nhs/helpers.py#L127-L140

that `resource_search` action takes a lot of time (~9s) + response size is 1.2MB

this is what they call from the helper function - you can try in browser:
https://opendata.nhsbsa.net/api/3/action/resource_search?query=name:

and it's getting slower and slower as they're adding new resources every month