### PR TITLE
fix/delete-create-member-theme

### DIFF
--- a/ckanext/nhs/plugin.py
+++ b/ckanext/nhs/plugin.py
@@ -81,6 +81,7 @@ class NHSPlugin(plugins.SingletonPlugin, DefaultTranslation):
                           'delete',
                           'admins',
                           'member_new',
+                          'members',
                           'member_delete',
                           'history'
                           'followers',

--- a/ckanext/nhs/templates/organization/confirm_delete_member.html
+++ b/ckanext/nhs/templates/organization/confirm_delete_member.html
@@ -10,7 +10,7 @@
       {% block form %}
         <p>{{ _('Are you sure you want to delete member - {name}?').format(name=c.user_dict.name) }}</p>
         <p class="form-actions">
-          <form action="{% url_for controller='organization', action='member_delete', id=c.group_id %}" method="post">
+          <form action="{% url_for controller='ckanext.nhs.controller:NhsOrganizationController', action='member_delete', id=c.group_id %}" method="post">
             <input type="hidden" name="user" value="{{ c.user_id }}" />
             <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
             <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>

--- a/ckanext/nhs/templates/organization/member_new.html
+++ b/ckanext/nhs/templates/organization/member_new.html
@@ -63,7 +63,7 @@
     {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        <a href="{{ h.url_for('theme_member_delete', id=c.group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+        <a href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Update Member') }}
         </button>


### PR DESCRIPTION
Fix for the issue in gitlab https://gitlab.com/datopian/core/support/-/issues/440
* Fix when user adds new member into the theme
* Fix when user deletes member from the theme members list
* Fix when user deletes member from the member edit page