### PR TITLE
User account features/fix Implementation 

### DIFF
--- a/ckanext/nhs/templates/user/read.html
+++ b/ckanext/nhs/templates/user/read.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+    {% if (h.check_access('package_create')) %}
+     {{ super() }}
+    {% endif %}
+ {% endblock %}

--- a/ckanext/nhs/templates/user/read_base.html
+++ b/ckanext/nhs/templates/user/read_base.html
@@ -17,8 +17,12 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('user.read', _('Datasets'), id=user.name) }}
-  {{ h.build_nav_icon('user.activity', _('Activity Stream'), id=user.name) }}
+  {% if (h.check_access('package_create')) %}
+    {{ h.build_nav_icon('user.read', _('Datasets'), id=user.name) }}
+    {{ h.build_nav_icon('user.activity', _('Activity Stream'), id=user.name) }}
+  {% else %}
+    &nbsp;
+  {% endif %}
 {% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
Issue : https://gitlab.com/datopian/clients/nhsbsa-opendata-pm-shared/-/issues/137

-  Enabled login and self registration 
    <img width="1440" alt="Screen Shot 2022-09-20 at 8 27 29 AM" src="https://user-images.githubusercontent.com/87696933/191155598-06f91e07-165c-4eef-a6f2-8233304e2f8a.png">

- Hide the tabs "My datasets", and "My organizations" for all users besides the sysadmins and added "Followed datasets", and "Followed themes" tabs listing datasets and themes that users following 
**Screenshot** 
    <img width="1437" alt="Screen Shot 2022-09-20 at 8 17 27 AM" src="https://user-images.githubusercontent.com/87696933/191154328-00dc3044-6a68-41ef-9637-2ae473dfda2a.png">
    
- Added feature to self-account delete
    **Screenshot** 
    <img width="919" alt="Screen Shot 2022-09-20 at 8 28 30 AM" src="https://user-images.githubusercontent.com/87696933/191155700-367d3708-2c22-4cf1-960c-2e4b3dc2be13.png">
